### PR TITLE
fix(branch): Add missing echo when emitting version string for main/m…

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,7 @@ fi
 ESCAPED_BRANCH=$(echo $BRANCH | sed 's/[^a-zA-Z0-9]/_/g')
 VERSION_DATE=$(date '+%Y.%m.%d.%s');
 
-VERSION=$(if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then $VERSION_DATE-$SHORT_SHA; else echo $ESCAPED_BRANCH-$VERSION_DATE-$SHORT_SHA; fi)
+VERSION=$(if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then echo $VERSION_DATE-$SHORT_SHA; else echo $ESCAPED_BRANCH-$VERSION_DATE-$SHORT_SHA; fi)
 
 echo "VERSION=$VERSION" >> $GITHUB_ENV
 echo "::set-output name=version::$VERSION"


### PR DESCRIPTION
[MAVRCK-10736](https://mavrck.atlassian.net/browse/MAVRCK-10736)

Add missing `echo` when emitting version string for `main/master` branch builds.