### PR TITLE
MVKPLTFRM-1041: updated the output method to the new method for githu…

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,8 +26,7 @@ VERSION_DATE=$(date '+%Y.%m.%d.%s');
 VERSION=$(if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then echo $VERSION_DATE-$SHORT_SHA; else echo $ESCAPED_BRANCH-$VERSION_DATE-$SHORT_SHA; fi)
 
 echo "VERSION=$VERSION" >> $GITHUB_ENV
-echo "::set-output name=version::$VERSION"
-
+echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 echo "Writing to $META_FILE_PATH"
 
 echo "authorName=$AUTHOR" > $META_FILE_PATH


### PR DESCRIPTION
Changed the output method for github actions to the new method as it is deprecated and will be removed "soon".  I will update the release version once this is merged into main.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/